### PR TITLE
Do not remove old blob if it doesn't exits

### DIFF
--- a/bump-blob.sh
+++ b/bump-blob.sh
@@ -3,34 +3,47 @@
 set -e
 set -o pipefail
 
+printf "Bumping Blob '%s' matching '%s'\n\n" ${BLOB_NAME} ${BLOB_REGEX}
+
 LATEST_VERSION=$(cat blob-input/version)
 BLOB=$(find blob-input -type f \( ! -name sha ! -name url ! -name version \) -printf "%f")
 
 cp -r repository-input/. repository-output
-
 cd repository-output
 
-OLD_BLOB_PATH=$(bosh blobs --column=path | egrep "${BLOB_REGEX}")
-OLD_VERSION=$([[ "${OLD_BLOB_PATH}" =~ $BOSH_REGEX ]] && echo ${BASH_REMATCH[1]})
+OLD_BLOB_PATH=$(bosh blobs --column=path | egrep "${BLOB_REGEX}" || true)
+if [[ ! -z ${OLD_BLOB_PATH} ]]; then
+  OLD_VERSION=$([[ "${OLD_BLOB_PATH}" =~ ${BLOB_REGEX} ]] && echo ${BASH_REMATCH[1]})
+else
+  OLD_VERSION="0"
+fi
 
 if [[ "${OLD_VERSION}" != "${LATEST_VERSION}" ]]; then
-  git config --global user.email ${CI_BOT_EMAIL}
-  git config --global user.name ${CI_BOT_USER}
+  printf "Version bump: '%s' to '%s'\n" "${OLD_VERSION}" "${LATEST_VERSION}"
+  printf "New blob    : %s\n" ${BLOB}
 
   cat << EOF > config/private.yml
 blobstore:
   options:
-    access_key_id: "$ACCESS_KEY_ID"
-    secret_access_key: "$SECRET_KEY"
+    access_key_id: "${ACCESS_KEY_ID}"
+    secret_access_key: "${SECRET_KEY}"
 EOF
 
-  bosh remove-blob $OLD_BLOB_PATH
+  if [[ ! -z ${OLD_BLOB_PATH} ]]; then
+    printf "Old blob    : %s\n\n" ${OLD_BLOB_PATH}
+    bosh remove-blob ${OLD_BLOB_PATH}
+  else
+    printf "Old blob    : not found, nothing to remove\n\n"
+  fi
+
   bosh add-blob ../blob-input/${BLOB} ${BLOB_NAME}/${BLOB}
   bosh upload-blobs
 
+  git config --global user.email ${CI_BOT_EMAIL}
+  git config --global user.name ${CI_BOT_USER}
   git add config/blobs.yml
   git status
   git commit -m "Bump ${BLOB_NAME} to ${LATEST_VERSION}"
 else
-  echo "Release has latest Blob version, skipping bump."
+  printf "Release has latest blob version (%s), skipping bump." ${LATEST_VERSION}
 fi

--- a/create-release.sh
+++ b/create-release.sh
@@ -8,8 +8,9 @@ RELEASE_VERSION=$(cat version-input/version)
 cp -r repository-input/. repository-output
 cd repository-output
 
-git config --global user.email ${CI_BOT_EMAIL}
-git config --global user.name ${CI_BOT_USER}
+RELEASE_NAME=$(egrep "^(final_)?name:" config/final.yml | cut -d " " -f 2 | xargs)
+
+printf "Creating '%s' Bosh release version '%s'\n\n" ${RELEASE_NAME} ${RELEASE_VERSION}
 
 cat << EOF > config/private.yml
 blobstore:
@@ -17,10 +18,10 @@ blobstore:
     access_key_id: "$ACCESS_KEY_ID"
     secret_access_key: "$SECRET_KEY"
 EOF
-
-RELEASE_NAME=$(egrep "^(final_)?name:" config/final.yml | cut -d " " -f 2 | xargs)
 bosh create-release --final --version="${RELEASE_VERSION}" --tarball ../release-tarball/${RELEASE_NAME}-release-${RELEASE_VERSION}.tgz
 
+git config --global user.email ${CI_BOT_EMAIL}
+git config --global user.name ${CI_BOT_USER}
 git add --all
 git status
 git commit -m "Create final release ${RELEASE_VERSION}"


### PR DESCRIPTION
On first release the old blob might not exits and `bosh remove-blob` 
fails.

Also corrected a bug where the old version of the blob wasn't match with the regex because the wrong variable was used.

Added some printf statements in both scripts.

Fixes #2 