### PR TITLE
Add support for re-creating existing releases

### DIFF
--- a/create-existing-release.sh
+++ b/create-existing-release.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+
+VERSION=$(cat github-release-input/version)
+
+BUILD_FOLDER=source
+mkdir -p ${BUILD_FOLDER}
+
+tar -xzf github-release-input/source.tar.gz --strip-components=1 -C ${BUILD_FOLDER}
+
+pushd ${BUILD_FOLDER} >/dev/null
+bosh create-release --final --version="${VERSION}+CUSTOM" --tarball ../release/${RELEASE_NAME}-${VERSION}.tgz
+popd >/dev/null
+
+if [[ -f github-release-input/body ]]; then
+  printf "release notes saved as ${RELEASE_NAME}-${VERSION}.md"
+  cp github-release-input/body release/${RELEASE_NAME}-${VERSION}.md
+else
+  printf "WARNING: no release notes provided with the release"
+fi
+
+cat <<EOF >notification/message.txt
+Successfully built ${RELEASE_NAME} version ${VERSION}
+EOF

--- a/create-existing-release.sh
+++ b/create-existing-release.sh
@@ -11,7 +11,7 @@ mkdir -p ${BUILD_FOLDER}
 tar -xzf github-release-input/source.tar.gz --strip-components=1 -C ${BUILD_FOLDER}
 
 pushd ${BUILD_FOLDER} >/dev/null
-bosh create-release --final --version="${VERSION}+CUSTOM" --tarball ../release/${RELEASE_NAME}-${VERSION}.tgz
+bosh create-release --version="${VERSION}+CUSTOM" --tarball ../release/${RELEASE_NAME}-${VERSION}.tgz
 popd >/dev/null
 
 if [[ -f github-release-input/body ]]; then

--- a/create-existing-release.yml
+++ b/create-existing-release.yml
@@ -1,0 +1,20 @@
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: starkandwayne/concourse
+
+inputs:
+  - name: pipeline-tasks
+  - name: github-release-input
+
+outputs:
+  - name: release
+  - name: notification
+
+run:
+  path: pipeline-tasks/create-existing-release.sh
+
+params:
+  RELEASE_NAME:


### PR DESCRIPTION
This will be used in the RabbitMQ pipeline to checkout the current release, rebuilt it and get the exported tarball which will be mirrored.

Also not the the releases will have the same release number but with `+CUSTOM` appended